### PR TITLE
Releaser: Don't delete all testing links during generations.

### DIFF
--- a/scripts/Releaser/downloads_host_publish.sh
+++ b/scripts/Releaser/downloads_host_publish.sh
@@ -51,7 +51,7 @@ rsync -vaH --remove-source-files * ../releases/
 cd ..
 
 rm -f *${end_tag_array[major]}.${end_tag_array[minor]}${end_tag_array[patchsep]}${end_tag_array[patch]}-rc*
-rm -f *-testing*
+rm -f *${end_tag_array[major]}-testing*
 
 if [ ${end_tag_array[release_type]} == "rc" ] ; then
 	# Create the direct links


### PR DESCRIPTION
Commit c28479c9b07f31a32b69da1140f30e8d92554a04 generates -testing links for each release candidate release, but deletes *all* testing links during the script. This is wrong, since this script is run once per major release, so this resulted in only the latest major version having a -testing release by the end.

To fix this, we use a properly targeted delete.

Resolves: #3